### PR TITLE
[BUGFIX] RandomIssueBody should match strlen size

### DIFF
--- a/src/Command/RandomIssueCommand.php
+++ b/src/Command/RandomIssueCommand.php
@@ -62,7 +62,7 @@ class RandomIssueCommand extends Command
         $randomIssueBody = $randomIssue->getBody();
 
         if (strlen($randomIssue->getBody()) > 300) {
-            $randomIssueBody = substr($randomIssue->getBody(), 0, 100) . '...';
+            $randomIssueBody = substr($randomIssue->getBody(), 0, 300) . '...';
         }
 
         $io->writeln($randomIssueBody);


### PR DESCRIPTION
The `$randomIssueBody` should be the same length as the length checking for in the if().

### All Submissions:

* [x] Does your PR have the correct target branch?
* [x] Have you followed the guidelines in our [Contributing document](../CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/<User>/<Repository>/pulls) for the same update/change?
