### PR TITLE
Add date created to output

### DIFF
--- a/src/Command/RandomIssueCommand.php
+++ b/src/Command/RandomIssueCommand.php
@@ -86,7 +86,6 @@ class RandomIssueCommand extends Command
         $randomIssue = $searchIssueModel->getItems()[$randomIssueIndex];
 
         $io->section($randomIssue->getTitle());
-        $io->writeln($randomIssue->getCreatedAt()->format('Y-m-d'));
         $io->writeln($randomIssue->getUrl());
         $io->newLine(2);
 

--- a/src/Command/RandomIssueCommand.php
+++ b/src/Command/RandomIssueCommand.php
@@ -60,7 +60,7 @@ class RandomIssueCommand extends Command
 
         /** @var string|null $languageInput */
         $languageInput = $input->getOption('language');
-        /** @var string|null  $labelInput */
+        /** @var string|null $labelInput */
         $labelInput = $input->getOption('label');
 
         $language = $languageInput ?? 'php';
@@ -86,6 +86,7 @@ class RandomIssueCommand extends Command
         $randomIssue = $searchIssueModel->getItems()[$randomIssueIndex];
 
         $io->section($randomIssue->getTitle());
+        $io->writeln($randomIssue->getCreatedAt()->format('Y-m-d'));
         $io->writeln($randomIssue->getUrl());
         $io->newLine(2);
 

--- a/src/Command/RandomIssueCommand.php
+++ b/src/Command/RandomIssueCommand.php
@@ -115,7 +115,7 @@ class RandomIssueCommand extends Command
         ]);
         $table->setRows([
             ['Link:', sprintf("<href=%s>%s</>", $randomIssue->getUrl(), $randomIssue->getUrl())],
-            ['Date Created:', $randomIssue->getCreatedAt()->format('jS F, Y')],
+            ['Date Created:', $randomIssue->getCreatedAt()->format('D, j M Y g:i A \U\T\C')],
             ['Status:', $randomIssue->getState()],
         ]);
         $table->setStyle('borderless');

--- a/src/Model/IssueModel.php
+++ b/src/Model/IssueModel.php
@@ -66,5 +66,4 @@ class IssueModel
     {
         return $this->state;
     }
-    
 }

--- a/src/Model/IssueModel.php
+++ b/src/Model/IssueModel.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Icanhazstring\RandomIssuePicker\Model;
 
 use JMS\Serializer\Annotation as Serializer;
+use Datetime;
 
 class IssueModel
 {
@@ -27,6 +28,13 @@ class IssueModel
      */
     private $body;
 
+    /**
+     * @var DateTime
+     * @Serializer\Type("DateTime")
+     * @Serializer\SerializedName("created_at")
+     */
+    private $createdAt;
+
     public function getUrl(): string
     {
         return $this->url;
@@ -40,5 +48,11 @@ class IssueModel
     public function getBody(): string
     {
         return $this->body;
+    }
+
+    public function getCreatedAt(): DateTime
+    {
+        $this->createdAt = new DateTime();
+        return $this->createdAt;
     }
 }


### PR DESCRIPTION
This PR aims to solve issue #8 

I have added a new attribute to the IssueModel.php which represents the created_date of a GitHub issue, implemented as a php DateTime class. Initially I displayed the value of this attribute to the output of RandomIssueCommand.execute() however in response to PR #10 by DenverCoder1 I have removed my changes to that class to prevent any merge conflicts. After that branch is merged (or rejected) I can push another commit to this PR that adds outputting the created_date before merging. From the wording of issue #8 only the date should be shown, not the full DateTime.

I reviewed GitHub's documentation available [here](https://docs.github.com/en/free-pro-team@latest/rest/reference/search#search-issues-and-pull-requests) and found that their API returns the "created_at", "updated_at" and "closed_at" datetimes. I assume that for now this tool only wants to pick issues that are not closed (which excludes showing the "closed_at" date), and I made the decision to only include the "created_at" date as I have found the "updated_at" date to be less important in my experience.

Note: An alternative implementation is to instantiate the new DateTime object in the constructor of IssueModel rather than every time getCreatedAt() is called. If we were to re-use the IssueModel multiple times then I think it would be better to instantiate in the constructor.

### All Submissions:

* [x] Does your PR have the correct target branch?
* [x] Have you followed the guidelines in our [Contributing document](../CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/<User>/<Repository>/pulls) for the same update/change?

### New Feature Submissions:

1. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
