### PR TITLE
Update reference to contributing document

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 ### All Submissions:
 
 * [ ] Does your PR have the correct target branch?
-* [ ] Have you followed the guidelines in our [Contributing document](../CONTRIBUTING.md)?
+* [ ] Have you followed the guidelines for [contributing](../#how-to-contribute)?
 * [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/<User>/<Repository>/pulls) for the same update/change?
 
 <!-- You can erase any parts of this template not applicable to your Pull Request. -->


### PR DESCRIPTION
Just link to relevant part of the README for contributing, instead of a non-existent document.

Fixes #17

### All Submissions:

* [x] Does your PR have the correct target branch?
* [x] Have you followed the guidelines in our [Contributing document](../CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/<User>/<Repository>/pulls) for the same update/change?